### PR TITLE
Add HTML5 ontology to the markup stack

### DIFF
--- a/crates/domains/src/manual_registrations.rs
+++ b/crates/domains/src/manual_registrations.rs
@@ -84,6 +84,16 @@ register_manual!(
 );
 
 register_manual!(
+    ident: HTML,
+    category: crate::social::software::markup::html::ontology::HtmlCategory,
+    entity: crate::social::software::markup::html::ontology::HtmlNodeKind,
+    name: "HTML",
+    module: "pr4xis_domains::social::software::markup::html",
+    source: "WHATWG HTML Living Standard",
+    being: SocialObject,
+);
+
+register_manual!(
     ident: RDF,
     category: crate::social::software::markup::xml::rdf::ontology::RdfCategory,
     entity: crate::social::software::markup::xml::rdf::ontology::RdfNodeKind,

--- a/crates/domains/src/social/software/markup/html/README.md
+++ b/crates/domains/src/social/software/markup/html/README.md
@@ -1,0 +1,5 @@
+# HTML5 Ontology
+
+A structural HTML5 ontology grounded in the WHATWG Living Standard.
+This module defines the categorical structure of HTML5 documents, including
+node kinds and containment relationships.

--- a/crates/domains/src/social/software/markup/html/citings.md
+++ b/crates/domains/src/social/software/markup/html/citings.md
@@ -1,0 +1,3 @@
+# Citations
+
+- WHATWG HTML Living Standard. https://html.spec.whatwg.org/multipage/

--- a/crates/domains/src/social/software/markup/html/mod.rs
+++ b/crates/domains/src/social/software/markup/html/mod.rs
@@ -1,6 +1,4 @@
-pub mod html;
 pub mod ontology;
-pub mod xml;
 
 pub use ontology::*;
 

--- a/crates/domains/src/social/software/markup/html/ontology.rs
+++ b/crates/domains/src/social/software/markup/html/ontology.rs
@@ -151,8 +151,13 @@ impl Classified for HtmlCategory {
 /// An HTML node.
 #[derive(Debug, Clone, PartialEq)]
 pub enum HtmlNode {
+    /// A DOCTYPE declaration.
+    Doctype(String),
+    /// An HTML element.
     Element(HtmlElement),
+    /// Text content.
     Text(String),
+    /// A comment.
     Comment(String),
 }
 
@@ -168,6 +173,13 @@ impl HtmlNode {
     /// Convert to the generic markup representation.
     pub fn to_markup(&self) -> MarkupNode {
         match self {
+            Self::Doctype(content) => MarkupNode {
+                kind: crate::social::software::markup::NodeKind::ProcessingInstruction,
+                name: Some("DOCTYPE".into()),
+                value: Some(content.clone()),
+                attributes: Vec::new(),
+                children: Vec::new(),
+            },
             Self::Element(elem) => {
                 let attrs: Vec<(&str, &str)> = elem
                     .attributes
@@ -189,13 +201,21 @@ impl HtmlNode {
 /// An HTML document.
 #[derive(Debug, Clone, PartialEq)]
 pub struct HtmlDocument {
+    /// The DOCTYPE declaration (optional but standard).
+    pub doctype: Option<String>,
+    /// The root element (typically <html>).
     pub root: HtmlElement,
 }
 
 impl HtmlDocument {
     /// Convert to generic markup representation.
     pub fn to_markup(&self) -> MarkupNode {
-        MarkupNode::document(vec![HtmlNode::Element(self.root.clone()).to_markup()])
+        let mut children = Vec::new();
+        if let Some(dt) = &self.doctype {
+            children.push(HtmlNode::Doctype(dt.clone()).to_markup());
+        }
+        children.push(HtmlNode::Element(self.root.clone()).to_markup());
+        MarkupNode::document(children)
     }
 }
 
@@ -204,11 +224,18 @@ pub struct HtmlSingleRootElement;
 
 impl pr4xis::logic::Axiom for HtmlSingleRootElement {
     fn description(&self) -> &str {
-        "an HTML document must have exactly one root element (WHATWG HTML §13.1)"
+        "an HTML document must have exactly one root element, which must be the <html> element (WHATWG HTML §13.1)"
     }
 
     fn holds(&self) -> bool {
-        true // structural — enforced by HtmlDocument having exactly one root field
+        true // structural — the single-root rule is enforced by the HtmlDocument type
+    }
+}
+
+impl HtmlSingleRootElement {
+    /// Check if a specific document satisfies the root element requirement.
+    pub fn is_satisfied_by(&self, doc: &HtmlDocument) -> bool {
+        doc.root.tag == "html"
     }
 }
 pr4xis::register_axiom!(HtmlSingleRootElement);

--- a/crates/domains/src/social/software/markup/html/ontology.rs
+++ b/crates/domains/src/social/software/markup/html/ontology.rs
@@ -1,0 +1,257 @@
+#[allow(unused_imports)]
+use alloc::{boxed::Box, format, string::String, string::ToString, vec, vec::Vec};
+
+use pr4xis::category::Category;
+use pr4xis::category::Concept;
+use pr4xis::category::relationship::Relationship;
+use pr4xis::ontology::upper::being::Being;
+use pr4xis::ontology::upper::classify::Classified;
+use pr4xis::ontology::{Axiom, Ontology, Quality};
+
+use super::super::ontology::MarkupNode;
+
+// HTML5 ontology — grounded in the WHATWG HTML Living Standard
+// https://html.spec.whatwg.org/multipage/
+//
+// HTML (HyperText Markup Language) is the standard markup language for
+// documents designed to be displayed in a web browser. This ontology
+// defines the structural elements of HTML5.
+
+/// HTML-specific node types.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Concept)]
+pub enum HtmlNodeKind {
+    /// The HTML document.
+    Document,
+    /// The DOCTYPE declaration: `<!DOCTYPE html>`.
+    Doctype,
+    /// An HTML element: `<div>`, `<p>`, etc.
+    Element,
+    /// An attribute: `class="foo"`.
+    Attribute,
+    /// Text content.
+    Text,
+    /// Comment: `<!-- ... -->`.
+    Comment,
+}
+
+/// HTML containment relationships.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HtmlContains {
+    pub parent: HtmlNodeKind,
+    pub child: HtmlNodeKind,
+}
+
+impl Relationship for HtmlContains {
+    type Object = HtmlNodeKind;
+    type Kind = ();
+    fn source(&self) -> HtmlNodeKind {
+        self.parent
+    }
+    fn target(&self) -> HtmlNodeKind {
+        self.child
+    }
+    fn kind(&self) {}
+}
+
+/// The HTML category — structural rules from WHATWG.
+pub struct HtmlCategory;
+
+impl Category for HtmlCategory {
+    type Object = HtmlNodeKind;
+    type Morphism = HtmlContains;
+
+    fn identity(obj: &HtmlNodeKind) -> HtmlContains {
+        HtmlContains {
+            parent: *obj,
+            child: *obj,
+        }
+    }
+
+    fn compose(f: &HtmlContains, g: &HtmlContains) -> Option<HtmlContains> {
+        if f.child != g.parent {
+            return None;
+        }
+        if f.parent == f.child {
+            return Some(g.clone());
+        }
+        if g.parent == g.child {
+            return Some(f.clone());
+        }
+        Some(HtmlContains {
+            parent: f.parent,
+            child: g.child,
+        })
+    }
+
+    fn morphisms() -> Vec<HtmlContains> {
+        use HtmlNodeKind::*;
+        let mut m = Vec::new();
+
+        // Identity
+        for n in HtmlNodeKind::variants() {
+            m.push(HtmlContains {
+                parent: n,
+                child: n,
+            });
+        }
+
+        // Document contains Doctype and Element (the <html> element)
+        m.push(HtmlContains {
+            parent: Document,
+            child: Doctype,
+        });
+        m.push(HtmlContains {
+            parent: Document,
+            child: Element,
+        });
+        m.push(HtmlContains {
+            parent: Document,
+            child: Comment,
+        });
+
+        // Element contains other elements, attributes, text, comments
+        m.push(HtmlContains {
+            parent: Element,
+            child: Element,
+        });
+        m.push(HtmlContains {
+            parent: Element,
+            child: Attribute,
+        });
+        m.push(HtmlContains {
+            parent: Element,
+            child: Text,
+        });
+        m.push(HtmlContains {
+            parent: Element,
+            child: Comment,
+        });
+
+        // Transitive closure (Document → Element → *)
+        for child in [Attribute, Text] {
+            m.push(HtmlContains {
+                parent: Document,
+                child,
+            });
+        }
+
+        m
+    }
+}
+
+impl Classified for HtmlCategory {
+    fn being() -> Being {
+        Being::SocialObject
+    }
+    fn classification_reason() -> &'static str {
+        "HTML is a WHATWG standard — a social convention for web document structure"
+    }
+}
+
+/// An HTML node.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HtmlNode {
+    Element(HtmlElement),
+    Text(String),
+    Comment(String),
+}
+
+/// An HTML element.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HtmlElement {
+    pub tag: String,
+    pub attributes: Vec<(String, String)>,
+    pub children: Vec<HtmlNode>,
+}
+
+impl HtmlNode {
+    /// Convert to the generic markup representation.
+    pub fn to_markup(&self) -> MarkupNode {
+        match self {
+            Self::Element(elem) => {
+                let attrs: Vec<(&str, &str)> = elem
+                    .attributes
+                    .iter()
+                    .map(|(k, v)| (k.as_str(), v.as_str()))
+                    .collect();
+                MarkupNode::element(
+                    &elem.tag,
+                    attrs,
+                    elem.children.iter().map(|c| c.to_markup()).collect(),
+                )
+            }
+            Self::Text(t) => MarkupNode::text(t),
+            Self::Comment(t) => MarkupNode::comment(t),
+        }
+    }
+}
+
+/// An HTML document.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HtmlDocument {
+    pub root: HtmlElement,
+}
+
+impl HtmlDocument {
+    /// Convert to generic markup representation.
+    pub fn to_markup(&self) -> MarkupNode {
+        MarkupNode::document(vec![HtmlNode::Element(self.root.clone()).to_markup()])
+    }
+}
+
+/// WHATWG well-formedness axiom: an HTML document has exactly one root element (the html element).
+pub struct HtmlSingleRootElement;
+
+impl pr4xis::logic::Axiom for HtmlSingleRootElement {
+    fn description(&self) -> &str {
+        "an HTML document must have exactly one root element (WHATWG HTML §13.1)"
+    }
+
+    fn holds(&self) -> bool {
+        true // structural — enforced by HtmlDocument having exactly one root field
+    }
+}
+pr4xis::register_axiom!(HtmlSingleRootElement);
+
+/// Structural quality: can this HTML node kind contain children?
+#[derive(Debug, Clone)]
+pub struct HtmlCanContainChildren;
+
+impl Quality for HtmlCanContainChildren {
+    type Individual = HtmlNodeKind;
+    type Value = ();
+
+    fn get(&self, kind: &HtmlNodeKind) -> Option<()> {
+        match kind {
+            HtmlNodeKind::Document | HtmlNodeKind::Element => Some(()),
+            _ => None,
+        }
+    }
+}
+
+/// The HTML ontology.
+pub struct HtmlOntology;
+
+impl Ontology for HtmlOntology {
+    type Cat = HtmlCategory;
+    type Qual = HtmlCanContainChildren;
+
+    fn domain_axioms() -> Vec<Box<dyn Axiom>> {
+        vec![Box::new(HtmlSingleRootElement)]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn category_laws() {
+        pr4xis::category::validate::check_category_laws::<HtmlCategory>().unwrap();
+    }
+
+    #[test]
+    fn ontology_validates() {
+        HtmlOntology::validate().unwrap();
+    }
+}

--- a/crates/domains/src/social/software/markup/html/tests.rs
+++ b/crates/domains/src/social/software/markup/html/tests.rs
@@ -1,0 +1,39 @@
+use super::ontology::*;
+
+#[test]
+fn test_html_to_markup_conversion() {
+    let html = HtmlDocument {
+        root: HtmlElement {
+            tag: "html".into(),
+            attributes: vec![("lang".into(), "en".into())],
+            children: vec![
+                HtmlNode::Element(HtmlElement {
+                    tag: "head".into(),
+                    attributes: vec![],
+                    children: vec![],
+                }),
+                HtmlNode::Element(HtmlElement {
+                    tag: "body".into(),
+                    attributes: vec![],
+                    children: vec![
+                        HtmlNode::Element(HtmlElement {
+                            tag: "h1".into(),
+                            attributes: vec![],
+                            children: vec![HtmlNode::Text("Hello HTML".into())],
+                        }),
+                        HtmlNode::Comment("A comment".into()),
+                    ],
+                }),
+            ],
+        },
+    };
+
+    let markup = html.to_markup();
+    assert_eq!(markup.kind, crate::social::software::markup::NodeKind::Document);
+    assert_eq!(markup.children.len(), 1);
+
+    let root = &markup.children[0];
+    assert_eq!(root.name.as_deref(), Some("html"));
+    assert_eq!(root.attribute("lang"), Some("en"));
+    assert_eq!(root.children.len(), 2);
+}

--- a/crates/domains/src/social/software/markup/html/tests.rs
+++ b/crates/domains/src/social/software/markup/html/tests.rs
@@ -3,6 +3,7 @@ use super::ontology::*;
 #[test]
 fn test_html_to_markup_conversion() {
     let html = HtmlDocument {
+        doctype: Some("html".into()),
         root: HtmlElement {
             tag: "html".into(),
             attributes: vec![("lang".into(), "en".into())],
@@ -29,11 +30,50 @@ fn test_html_to_markup_conversion() {
     };
 
     let markup = html.to_markup();
-    assert_eq!(markup.kind, crate::social::software::markup::NodeKind::Document);
-    assert_eq!(markup.children.len(), 1);
+    assert_eq!(
+        markup.kind,
+        crate::social::software::markup::NodeKind::Document
+    );
+    // Doctype + Root
+    assert_eq!(markup.children.len(), 2);
 
-    let root = &markup.children[0];
+    let doctype = &markup.children[0];
+    assert_eq!(
+        doctype.kind,
+        crate::social::software::markup::NodeKind::ProcessingInstruction
+    );
+    assert_eq!(doctype.name.as_deref(), Some("DOCTYPE"));
+    assert_eq!(doctype.value.as_deref(), Some("html"));
+
+    let root = &markup.children[1];
     assert_eq!(root.name.as_deref(), Some("html"));
     assert_eq!(root.attribute("lang"), Some("en"));
     assert_eq!(root.children.len(), 2);
+}
+
+#[test]
+fn test_html_axiom_validation() {
+    let axiom = HtmlSingleRootElement;
+
+    // Valid: rooted at <html>
+    let valid_html = HtmlDocument {
+        doctype: None,
+        root: HtmlElement {
+            tag: "html".into(),
+            attributes: vec![],
+            children: vec![],
+        },
+    };
+    assert!(axiom.is_satisfied_by(&valid_html));
+
+    // Invalid: rooted at <div>
+    let invalid_html = HtmlDocument {
+        doctype: None,
+        root: HtmlElement {
+            tag: "div".into(),
+            attributes: vec![],
+            children: vec![],
+        },
+    };
+    assert!(!axiom.is_satisfied_by(&invalid_html));
 }


### PR DESCRIPTION
This PR adds the HTML5 ontology to the `pr4xis` markup stack. It mirrors the existing XML ontology structure, defining HTML-specific node types and containment rules according to the WHATWG HTML Living Standard. The ontology is wired into the module tree and registered in `manual_registrations.rs`. Tests are included to verify the categorical laws and the conversion from HTML to the generic markup representation.

Fixes #1

---
*PR created automatically by Jules for task [535787070422952344](https://jules.google.com/task/535787070422952344) started by @awfmilton*