### PR TITLE
Add HTML5 ontology to the markup stack

### DIFF
--- a/crates/domains/src/manual_registrations.rs
+++ b/crates/domains/src/manual_registrations.rs
@@ -84,6 +84,16 @@ register_manual!(
 );
 
 register_manual!(
+    ident: HTML,
+    category: crate::social::software::markup::html::ontology::HtmlCategory,
+    entity: crate::social::software::markup::html::ontology::HtmlNodeKind,
+    name: "HTML",
+    module: "pr4xis_domains::social::software::markup::html",
+    source: "WHATWG HTML Living Standard",
+    being: SocialObject,
+);
+
+register_manual!(
     ident: RDF,
     category: crate::social::software::markup::xml::rdf::ontology::RdfCategory,
     entity: crate::social::software::markup::xml::rdf::ontology::RdfNodeKind,

--- a/crates/domains/src/social/software/markup/html/README.md
+++ b/crates/domains/src/social/software/markup/html/README.md
@@ -1,0 +1,40 @@
+# HTML5 -- WHATWG HTML Ontology
+
+Models HTML5 as an extension of the parent markup ontology: the universal node kinds are mapped to HTML5 constructs (Document, DocType, Element, Attribute, Text, Comment) and the WHATWG structural rules are enforced as category and axioms.
+
+Key references:
+- [WHATWG HTML Living Standard](https://html.spec.whatwg.org/multipage/)
+
+## Entities
+
+| Category | Entities |
+|---|---|
+| HTML node kinds (6) | Document, DocType, Element, Attribute, Text, Comment |
+
+## Category
+
+`HtmlCategory` has `HtmlNodeKind` as objects and `HtmlContains` as morphisms. The edge set encodes the basic HTML structural rules: `Document → {DocType, Element, Comment}`; `Element → {Element, Attribute, Text, Comment}`; plus the transitive closure `Document → {Attribute, Text}`.
+
+## Qualities
+
+| Quality | Type | Description |
+|---|---|---|
+| IsContentNode | () | Element, Text, and Comment are content nodes; Attribute, Document, and DocType are not |
+
+## Axioms (2)
+
+| Axiom | Description | Source |
+|---|---|---|
+| SingleRootElement | An HTML document must have exactly one root element | WHATWG HTML §13.2.1 |
+| ProperNesting | HTML elements must be properly nested — no overlapping tags | WHATWG HTML §13.2 |
+
+## Functors
+
+HTML extends the parent `markup` ontology; `HtmlNode::to_markup` and `HtmlDocument::to_markup` realise the forgetful direction by projecting HTML trees onto generic `MarkupNode` trees.
+
+## Files
+
+- `ontology.rs` -- `HtmlNodeKind`, `HtmlContains`, `HtmlCategory`/`HtmlOntology`, `HtmlDocument`/`HtmlElement`/`HtmlAttribute`/`HtmlNode` rich types, `IsContentNode` quality, `SingleRootElement`/`ProperNesting` axioms, tests
+- `tests.rs` -- structural and conversion tests
+- `mod.rs` -- module declarations
+- `citings.md` -- references to the WHATWG HTML Living Standard

--- a/crates/domains/src/social/software/markup/html/citings.md
+++ b/crates/domains/src/social/software/markup/html/citings.md
@@ -1,0 +1,17 @@
+# Citings — HTML5 -- WHATWG HTML Ontology
+
+Every published source this ontology stands on.
+
+## Primary sources
+
+- [WHATWG HTML Living Standard](https://html.spec.whatwg.org/multipage/)
+
+## Cross-references
+
+- Workspace bibliography: [`docs/papers/references.md`](../../../../../../../docs/papers/references.md)
+- Source attributions per axiom: see the `Source` column in the `## Axioms` table in [`README.md`](README.md)
+
+---
+
+- **Document date:** 2026-05-23
+- **How this file is maintained:** manual updates as the ontology evolves.

--- a/crates/domains/src/social/software/markup/html/mod.rs
+++ b/crates/domains/src/social/software/markup/html/mod.rs
@@ -1,6 +1,4 @@
-pub mod html;
 pub mod ontology;
-pub mod xml;
 
 pub use ontology::*;
 

--- a/crates/domains/src/social/software/markup/html/ontology.rs
+++ b/crates/domains/src/social/software/markup/html/ontology.rs
@@ -1,0 +1,295 @@
+#[allow(unused_imports)]
+use alloc::{boxed::Box, format, string::String, string::ToString, vec, vec::Vec};
+
+use pr4xis::category::Category;
+use pr4xis::category::Concept;
+use pr4xis::category::relationship::Relationship;
+use pr4xis::ontology::upper::being::Being;
+use pr4xis::ontology::upper::classify::Classified;
+use pr4xis::ontology::{Axiom, Ontology, Quality};
+
+use super::super::ontology::MarkupNode;
+
+// HTML5 ontology — grounded in the WHATWG HTML Living Standard.
+// https://html.spec.whatwg.org/multipage/
+//
+// HTML (HyperText Markup Language) is the standard markup language for documents
+// designed to be displayed in a web browser. This ontology defines the structural
+// essence of HTML5 as a categorical structure.
+
+/// HTML-specific node kinds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Concept)]
+pub enum HtmlNodeKind {
+    /// The HTML document itself.
+    Document,
+    /// The DOCTYPE declaration: `<!DOCTYPE html>`.
+    DocType,
+    /// An HTML element: `<div>`, `<p>`, `<span>`, etc.
+    Element,
+    /// An HTML attribute: `class="container"`, `id="main"`.
+    Attribute,
+    /// Text content within an element.
+    Text,
+    /// An HTML comment: `<!-- comment -->`.
+    Comment,
+}
+
+/// HTML containment relationships.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HtmlContains {
+    pub parent: HtmlNodeKind,
+    pub child: HtmlNodeKind,
+}
+
+impl Relationship for HtmlContains {
+    type Object = HtmlNodeKind;
+    type Kind = ();
+    fn source(&self) -> HtmlNodeKind {
+        self.parent
+    }
+    fn target(&self) -> HtmlNodeKind {
+        self.child
+    }
+    fn kind(&self) {}
+}
+
+/// The HTML category — structural rules as category laws.
+pub struct HtmlCategory;
+
+impl Category for HtmlCategory {
+    type Object = HtmlNodeKind;
+    type Morphism = HtmlContains;
+
+    fn identity(obj: &HtmlNodeKind) -> HtmlContains {
+        HtmlContains {
+            parent: *obj,
+            child: *obj,
+        }
+    }
+
+    fn compose(f: &HtmlContains, g: &HtmlContains) -> Option<HtmlContains> {
+        if f.child != g.parent {
+            return None;
+        }
+        if f.parent == f.child {
+            return Some(g.clone());
+        }
+        if g.parent == g.child {
+            return Some(f.clone());
+        }
+        Some(HtmlContains {
+            parent: f.parent,
+            child: g.child,
+        })
+    }
+
+    fn morphisms() -> Vec<HtmlContains> {
+        use HtmlNodeKind::*;
+        let mut m = Vec::new();
+
+        // Identity
+        for n in HtmlNodeKind::variants() {
+            m.push(HtmlContains {
+                parent: n,
+                child: n,
+            });
+        }
+
+        // Document contains Doctype, Element (root), and Comments
+        m.push(HtmlContains {
+            parent: Document,
+            child: DocType,
+        });
+        m.push(HtmlContains {
+            parent: Document,
+            child: Element,
+        });
+        m.push(HtmlContains {
+            parent: Document,
+            child: Comment,
+        });
+
+        // Element contains other Elements, Attributes, Text, and Comments
+        m.push(HtmlContains {
+            parent: Element,
+            child: Element,
+        });
+        m.push(HtmlContains {
+            parent: Element,
+            child: Attribute,
+        });
+        m.push(HtmlContains {
+            parent: Element,
+            child: Text,
+        });
+        m.push(HtmlContains {
+            parent: Element,
+            child: Comment,
+        });
+
+        // Transitive closure (Document → Element → *)
+        for child in [Attribute, Text] {
+            m.push(HtmlContains {
+                parent: Document,
+                child,
+            });
+        }
+
+        m
+    }
+}
+
+impl Classified for HtmlCategory {
+    fn being() -> Being {
+        Being::SocialObject
+    }
+    fn classification_reason() -> &'static str {
+        "HTML5 is a WHATWG/W3C standard social convention for web documents"
+    }
+}
+
+/// An HTML element.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HtmlElement {
+    pub name: String,
+    pub attributes: Vec<HtmlAttribute>,
+    pub children: Vec<HtmlNode>,
+}
+
+/// An HTML attribute.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HtmlAttribute {
+    pub name: String,
+    pub value: String,
+}
+
+/// An HTML node — universal representation of HTML content.
+#[derive(Debug, Clone, PartialEq)]
+pub enum HtmlNode {
+    Element(HtmlElement),
+    Text(String),
+    Comment(String),
+}
+
+impl HtmlNode {
+    /// Convert to the generic markup representation.
+    pub fn to_markup(&self) -> MarkupNode {
+        match self {
+            Self::Element(elem) => {
+                let attrs: Vec<(&str, &str)> = elem
+                    .attributes
+                    .iter()
+                    .map(|a| (a.name.as_str(), a.value.as_str()))
+                    .collect();
+                MarkupNode::element(
+                    &elem.name,
+                    attrs,
+                    elem.children.iter().map(|c| c.to_markup()).collect(),
+                )
+            }
+            Self::Text(t) => MarkupNode::text(t),
+            Self::Comment(t) => MarkupNode::comment(t),
+        }
+    }
+
+    /// Get text content recursively.
+    pub fn text_content(&self) -> String {
+        match self {
+            Self::Text(t) => t.clone(),
+            Self::Element(elem) => elem
+                .children
+                .iter()
+                .map(|c| c.text_content())
+                .collect::<Vec<_>>()
+                .join(""),
+            _ => String::new(),
+        }
+    }
+}
+
+/// An HTML document.
+#[derive(Debug, Clone, PartialEq)]
+pub struct HtmlDocument {
+    pub doctype: Option<String>,
+    pub root: HtmlElement,
+}
+
+impl HtmlDocument {
+    /// Convert to generic markup representation.
+    pub fn to_markup(&self) -> MarkupNode {
+        // DocType is handled as a sibling or metadata in generic markup if needed,
+        // but base MarkupNode doesn't have a specific DocType kind yet.
+        MarkupNode::document(vec![HtmlNode::Element(self.root.clone()).to_markup()])
+    }
+}
+
+/// HTML well-formedness: an HTML document must have exactly one root element.
+pub struct SingleRootElement;
+
+impl pr4xis::logic::Axiom for SingleRootElement {
+    fn description(&self) -> &str {
+        "an HTML document must have exactly one root element (the html element)"
+    }
+
+    fn holds(&self) -> bool {
+        true // structural — enforced by HtmlDocument having exactly one root field
+    }
+}
+pr4xis::register_axiom!(SingleRootElement);
+
+/// HTML well-formedness: elements must be properly nested.
+pub struct ProperNesting;
+
+impl pr4xis::logic::Axiom for ProperNesting {
+    fn description(&self) -> &str {
+        "HTML elements must be properly nested — no overlapping tags"
+    }
+
+    fn holds(&self) -> bool {
+        true // structural — enforced by the tree representation
+    }
+}
+pr4xis::register_axiom!(ProperNesting);
+
+/// Quality: is this HTML node kind a content node?
+#[derive(Debug, Clone)]
+pub struct IsContentNode;
+
+impl Quality for IsContentNode {
+    type Individual = HtmlNodeKind;
+    type Value = ();
+
+    fn get(&self, kind: &HtmlNodeKind) -> Option<()> {
+        match kind {
+            HtmlNodeKind::Element | HtmlNodeKind::Text | HtmlNodeKind::Comment => Some(()),
+            _ => None,
+        }
+    }
+}
+
+/// The HTML ontology.
+pub struct HtmlOntology;
+
+impl Ontology for HtmlOntology {
+    type Cat = HtmlCategory;
+    type Qual = IsContentNode;
+
+    fn domain_axioms() -> Vec<Box<dyn Axiom>> {
+        vec![Box::new(SingleRootElement), Box::new(ProperNesting)]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn category_laws() {
+        pr4xis::category::validate::check_category_laws::<HtmlCategory>().unwrap();
+    }
+
+    #[test]
+    fn ontology_validates() {
+        HtmlOntology::validate().unwrap();
+    }
+}

--- a/crates/domains/src/social/software/markup/html/tests.rs
+++ b/crates/domains/src/social/software/markup/html/tests.rs
@@ -1,0 +1,75 @@
+use super::super::ontology::NodeKind;
+use super::*;
+
+#[test]
+fn test_html_to_markup() {
+    let html = HtmlDocument {
+        doctype: Some("html".into()),
+        root: HtmlElement {
+            name: "html".into(),
+            attributes: vec![HtmlAttribute {
+                name: "lang".into(),
+                value: "en".into(),
+            }],
+            children: vec![
+                HtmlNode::Element(HtmlElement {
+                    name: "head".into(),
+                    attributes: Vec::new(),
+                    children: Vec::new(),
+                }),
+                HtmlNode::Element(HtmlElement {
+                    name: "body".into(),
+                    attributes: Vec::new(),
+                    children: vec![
+                        HtmlNode::Element(HtmlElement {
+                            name: "h1".into(),
+                            attributes: Vec::new(),
+                            children: vec![HtmlNode::Text("Hello HTML5".into())],
+                        }),
+                        HtmlNode::Comment("A comment".into()),
+                    ],
+                }),
+            ],
+        },
+    };
+
+    let markup = html.to_markup();
+    assert_eq!(markup.kind, NodeKind::Document);
+    assert_eq!(markup.children.len(), 1);
+
+    let root = &markup.children[0];
+    assert_eq!(root.kind, NodeKind::Element);
+    assert_eq!(root.name.as_deref(), Some("html"));
+    assert_eq!(root.attribute("lang"), Some("en"));
+    assert_eq!(root.children.len(), 2);
+
+    let body = &root.children[1];
+    assert_eq!(body.name.as_deref(), Some("body"));
+    assert_eq!(body.children.len(), 2);
+
+    let h1 = &body.children[0];
+    assert_eq!(h1.name.as_deref(), Some("h1"));
+    assert_eq!(h1.text_content(), "Hello HTML5");
+
+    let comment = &body.children[1];
+    assert_eq!(comment.kind, NodeKind::Comment);
+    assert_eq!(comment.value.as_deref(), Some("A comment"));
+}
+
+#[test]
+fn test_html_text_content() {
+    let node = HtmlNode::Element(HtmlElement {
+        name: "p".into(),
+        attributes: Vec::new(),
+        children: vec![
+            HtmlNode::Text("Part 1 ".into()),
+            HtmlNode::Element(HtmlElement {
+                name: "span".into(),
+                attributes: Vec::new(),
+                children: vec![HtmlNode::Text("Part 2".into())],
+            }),
+        ],
+    });
+
+    assert_eq!(node.text_content(), "Part 1 Part 2");
+}


### PR DESCRIPTION
Implemented a structural HTML5 ontology as a categorical structure within the markup stack. Added entities, relationships, axioms, and rich types, along with tests and documentation. Verified `no_std` compatibility and passed all tests and lints.

Fixes #1

---
*PR created automatically by Jules for task [17067499211580760073](https://jules.google.com/task/17067499211580760073) started by @awfmilton*