### PR TITLE
Fix interrogative parsing, math operator preservation, and repair loop gibberish

### DIFF
--- a/crates/domains/src/cognitive/linguistics/lambek/tests.rs
+++ b/crates/domains/src/cognitive/linguistics/lambek/tests.rs
@@ -277,10 +277,38 @@ fn is_a_dog_a_mammal_question() {
 }
 
 #[test]
+fn are_you_big_question() {
+    let tokens = tokenize::tokenize("are you big", &sample_lang());
+    assert_eq!(tokens.len(), 3);
+    assert_eq!(tokens[0].lambek_type, svo::question_copula_adj());
+    assert_eq!(tokens[2].lambek_type, svo::predicate_adjective());
+    let result = reduce_sequence(&tokens);
+    assert!(result.success, "expected Q, got {:?}", result.remaining);
+    assert_eq!(result.final_type, Some(LambekType::q()));
+}
+
+#[test]
 fn what_is_a_dog() {
     let tokens = tokenize::tokenize("what is a dog", &sample_lang());
     assert_eq!(tokens.len(), 4);
     assert_eq!(tokens[0].lambek_type, svo::wh_what()); // what
+}
+
+#[test]
+fn tokenize_how_are_you() {
+    let tokens = tokenize::tokenize("how are you", &sample_lang());
+    assert_eq!(tokens.len(), 3);
+    assert_eq!(tokens[0].word, "how");
+    assert_eq!(tokens[0].lambek_type, svo::wh_how());
+}
+
+#[test]
+fn tokenize_math_operators() {
+    let tokens = tokenize::tokenize("1 + 1", &sample_lang());
+    assert_eq!(tokens.len(), 3);
+    assert_eq!(tokens[0].word, "1");
+    assert_eq!(tokens[1].word, "+");
+    assert_eq!(tokens[2].word, "1");
 }
 
 // =============================================================================

--- a/crates/domains/src/cognitive/linguistics/lambek/tokenize.rs
+++ b/crates/domains/src/cognitive/linguistics/lambek/tokenize.rs
@@ -21,7 +21,7 @@ use pr4xis::category::entity::Concept;
 pub fn tokenize(text: &str, language: &dyn Language) -> Vec<TypedToken> {
     let cleaned = text
         .trim()
-        .trim_end_matches(|c: char| c.is_ascii_punctuation());
+        .trim_end_matches(|c: char| c.is_ascii_punctuation() && !"+-*/=".contains(c));
 
     let words: Vec<&str> = cleaned.split_whitespace().collect();
 
@@ -29,7 +29,8 @@ pub fn tokenize(text: &str, language: &dyn Language) -> Vec<TypedToken> {
         .iter()
         .enumerate()
         .filter_map(|(i, word)| {
-            let word_clean = word.trim_matches(|c: char| c.is_ascii_punctuation());
+            let word_clean =
+                word.trim_matches(|c: char| c.is_ascii_punctuation() && !"+-*/=".contains(c));
             if word_clean.is_empty() {
                 return None;
             }
@@ -44,6 +45,7 @@ pub fn tokenize(text: &str, language: &dyn Language) -> Vec<TypedToken> {
 
     // Post-processing: assign predicate adjective types based on context.
     assign_predicate_adjectives(&mut tokens);
+    assign_question_copula_adj(&mut tokens);
 
     tokens
 }
@@ -56,7 +58,7 @@ pub fn tokenize_with_alternatives(
 ) -> (Vec<TypedToken>, Vec<Vec<LambekType>>) {
     let cleaned = text
         .trim()
-        .trim_end_matches(|c: char| c.is_ascii_punctuation());
+        .trim_end_matches(|c: char| c.is_ascii_punctuation() && !"+-*/=".contains(c));
 
     let words: Vec<&str> = cleaned.split_whitespace().collect();
 
@@ -64,7 +66,8 @@ pub fn tokenize_with_alternatives(
     let mut alternatives = Vec::new();
 
     for (i, word) in words.iter().enumerate() {
-        let word_clean = word.trim_matches(|c: char| c.is_ascii_punctuation());
+        let word_clean =
+            word.trim_matches(|c: char| c.is_ascii_punctuation() && !"+-*/=".contains(c));
         if word_clean.is_empty() {
             continue;
         }
@@ -91,6 +94,7 @@ pub fn tokenize_with_alternatives(
     }
 
     assign_predicate_adjectives(&mut tokens);
+    assign_question_copula_adj(&mut tokens);
 
     (tokens, alternatives)
 }
@@ -104,7 +108,7 @@ pub fn tokenize_with_alternatives(
 pub fn tokenize_ontological(text: &str, language: &dyn Language) -> Vec<Token> {
     let cleaned = text
         .trim()
-        .trim_end_matches(|c: char| c.is_ascii_punctuation());
+        .trim_end_matches(|c: char| c.is_ascii_punctuation() && !"+-*/=".contains(c));
 
     let words: Vec<&str> = cleaned.split_whitespace().collect();
 
@@ -112,7 +116,8 @@ pub fn tokenize_ontological(text: &str, language: &dyn Language) -> Vec<Token> {
         .iter()
         .enumerate()
         .filter_map(|(i, word)| {
-            let word_clean = word.trim_matches(|c: char| c.is_ascii_punctuation());
+            let word_clean =
+                word.trim_matches(|c: char| c.is_ascii_punctuation() && !"+-*/=".contains(c));
             if word_clean.is_empty() {
                 return None;
             }
@@ -136,6 +141,7 @@ pub fn tokenize_ontological(text: &str, language: &dyn Language) -> Vec<Token> {
         .collect();
 
     assign_predicate_adjectives_typed(&mut tokens);
+    assign_question_copula_adj_typed(&mut tokens);
     tokens
 }
 
@@ -147,6 +153,33 @@ fn assign_predicate_adjectives_typed(tokens: &mut [Token]) {
         if is_copula && is_adj {
             tokens[i].lambek_type = svo_types::copula_adj();
             tokens[i + 1].lambek_type = svo_types::predicate_adjective();
+        }
+    }
+}
+
+/// Post-processing for interrogatives: is a dog big?
+/// Initial question copula followed by adjective (at index 3 usually, but we check all).
+fn assign_question_copula_adj(tokens: &mut [TypedToken]) {
+    if tokens.is_empty() || tokens[0].lambek_type != svo_types::question_copula() {
+        return;
+    }
+    // "is a dog big" -> is:0 a:1 dog:2 big:3
+    for i in 1..tokens.len() {
+        if tokens[i].lambek_type == svo_types::adjective() {
+            tokens[0].lambek_type = svo_types::question_copula_adj();
+            tokens[i].lambek_type = svo_types::predicate_adjective();
+        }
+    }
+}
+
+fn assign_question_copula_adj_typed(tokens: &mut [Token]) {
+    if tokens.is_empty() || tokens[0].lambek_type != svo_types::question_copula() {
+        return;
+    }
+    for i in 1..tokens.len() {
+        if tokens[i].lambek_type == svo_types::adjective() {
+            tokens[0].lambek_type = svo_types::question_copula_adj();
+            tokens[i].lambek_type = svo_types::predicate_adjective();
         }
     }
 }
@@ -169,6 +202,9 @@ fn assign_type(word: &str, position: usize, language: &dyn Language) -> LambekTy
 
         // Interrogative pronouns at sentence start → wh-question type
         if first.is_some_and(|e| e.is_interrogative()) {
+            if word.eq_ignore_ascii_case("how") {
+                return svo_types::wh_how();
+            }
             return svo_types::wh_what();
         }
     }

--- a/crates/domains/src/cognitive/linguistics/lambek/types.rs
+++ b/crates/domains/src/cognitive/linguistics/lambek/types.rs
@@ -294,6 +294,15 @@ pub mod svo {
         )
     }
 
+    /// Question copula with adjective: (S[q]/(S[adj]\NP))/NP
+    /// "are" in "are you happy?" — takes NP then predicate adjective.
+    pub fn question_copula_adj() -> LambekType {
+        LambekType::right_div(
+            LambekType::right_div(LambekType::q(), predicate_adjective()),
+            LambekType::np(),
+        )
+    }
+
     /// Ditransitive verb: ((NP\S)/NP)/NP — "gives"
     pub fn ditransitive_verb() -> LambekType {
         LambekType::right_div(transitive_verb(), LambekType::np())
@@ -362,6 +371,14 @@ pub mod svo {
     pub fn wh_what() -> LambekType {
         // CCGbank: S[wq]/(S[dcl]\NP) — takes a sentence-missing-subject on the right.
         // "what is a dog" → what + [is a dog : NP\S] → S[wq]
+        LambekType::right_div(
+            LambekType::wq(),
+            LambekType::left_div(LambekType::np(), LambekType::s()),
+        )
+    }
+
+    /// "how" as question word: S[wq]/(S/NP) — "how are you?"
+    pub fn wh_how() -> LambekType {
         LambekType::right_div(
             LambekType::wq(),
             LambekType::left_div(LambekType::np(), LambekType::s()),

--- a/crates/domains/src/cognitive/linguistics/language.rs
+++ b/crates/domains/src/cognitive/linguistics/language.rs
@@ -626,6 +626,11 @@ fn build_english_function_words_embedded() -> HashMap<String, Vec<LexicalEntry>>
         }));
     }
 
+    // ---- Interrogative Adverbs (OLiA: InterrogativeAdverb) ----
+    add(LexicalEntry::Adverb(Adverb {
+        text: "how".into(),
+    }));
+
     // ---- Prepositions (OLiA: Preposition) ----
     for text in [
         "in", "on", "at", "with", "to", "from", "by", "for", "of", "about", "into", "through",

--- a/crates/domains/src/cognitive/linguistics/lexicon/pos.rs
+++ b/crates/domains/src/cognitive/linguistics/lexicon/pos.rs
@@ -271,11 +271,12 @@ impl LexicalEntry {
         }
     }
 
-    /// Is this an interrogative pronoun?
-    /// Determined by the OLiA classification, not by the word itself.
+    /// Is this an interrogative pronoun or adverb?
+    /// Determined by the OLiA classification, or the word itself for adverbs.
     pub fn is_interrogative(&self) -> bool {
         match self {
             Self::Pronoun(p) => p.kind == PronounKind::Interrogative,
+            Self::Adverb(a) => a.text == "how",
             _ => false,
         }
     }

--- a/crates/domains/src/cognitive/linguistics/pragmatics/realize.rs
+++ b/crates/domains/src/cognitive/linguistics/pragmatics/realize.rs
@@ -206,7 +206,12 @@ fn realize_gap(content: &ResponseContent) -> String {
 }
 
 fn realize_suggestion(content: &ResponseContent) -> String {
-    if content.entities.len() >= 2 {
+    let has_math = content
+        .entities
+        .iter()
+        .any(|e| e.chars().any(|c| "+-*/=".contains(c)));
+
+    if content.entities.len() == 2 && !has_math {
         // Generate a question from the found concepts
         let question = sentence_question(&content.entities[0], &content.entities[1]);
         return format!(
@@ -323,6 +328,17 @@ mod tests {
         let content = ResponseContent::new(ResponseFrame::AdmitLimitation);
         let text = realize(&content);
         assert!(text.contains("is a dog a mammal?"));
+    }
+
+    #[test]
+    fn suggestion_avoids_gibberish_for_math() {
+        let content = ResponseContent::new(ResponseFrame::SuggestInterpretation)
+            .with_entity("1")
+            .with_entity("+")
+            .with_entity("1");
+        let text = realize(&content);
+        assert!(text.contains("I know the words \"1\", \"+\", \"1\""));
+        assert!(!text.contains("Did you mean:"));
     }
 
     #[test]


### PR DESCRIPTION
This PR addresses issues in the Lambek Grammar pipeline where standard interrogatives failed to parse, mathematical operators were dropped, and the repair loop generated nonsensical suggestions.

Key changes:
1. **Tokenizer updates**: Modified `tokenize.rs` to exclude mathematical operators from trimmable punctuation. Added case-insensitive matching for "how".
2. **Interrogative support**: Added "how" as an interrogative adverb in `pos.rs` and `language.rs`. Introduced `wh_how` and `question_copula_adj` types in `types.rs`.
3. **Repair loop refinement**: Updated `realize_suggestion` in `realize.rs` to provide more sensible fallbacks when a structured subject-complement question cannot be formed.
4. **Verification**: Added comprehensive unit tests for the new functionality and verified that they pass along with the rest of the relevant test suite.

Fixes #5

---
*PR created automatically by Jules for task [7565922808955306562](https://jules.google.com/task/7565922808955306562) started by @awfmilton*