### PR TITLE
refactor: resolve duplicate Morphism types

### DIFF
--- a/crates/pr4xis/src/category/kleisli.rs
+++ b/crates/pr4xis/src/category/kleisli.rs
@@ -9,7 +9,7 @@ use super::relationship::Relationship;
 //   Composition: f >=> g = |a| f(a) >>= g (monadic composition)
 //   Identity: pure/return
 //
-// In pr4xis, Category::compose returns Option<Morphism>.
+// In pr4xis, Category::compose returns Option<C::Morphism>.
 // This IS the Kleisli category for the Maybe monad:
 //   Objects: Entity variants
 //   Morphisms: the morphisms that may or may not compose

--- a/crates/pr4xis/src/category/mod.rs
+++ b/crates/pr4xis/src/category/mod.rs
@@ -49,7 +49,7 @@ pub use kleisli::KleisliMorphism;
 pub use monad::Writer;
 pub use monoid::Monoid;
 pub use monoidal::{Coproduct, Product};
-pub use morphism::{Morphism, compose_all, direct_morphisms};
+pub use morphism::{BoundMorphism, compose_all, direct_morphisms};
 pub use op::{Op, OpMorphism};
 pub use optics::{Iso, Lens, Prism};
 #[doc(hidden)]

--- a/crates/pr4xis/src/category/morphism.rs
+++ b/crates/pr4xis/src/category/morphism.rs
@@ -7,16 +7,16 @@ use alloc::{boxed::Box, format, string::String, string::ToString, vec, vec::Vec}
 ///
 /// Wraps a raw relationship with its category context so you can write:
 /// ```ignore
-/// Morphism::of::<MyCat>(f)
+/// BoundMorphism::of::<MyCat>(f)
 ///     .then(&g)
 ///     .then(&h)
 /// ```
 #[derive(Debug, Clone)]
-pub struct Morphism<C: Category> {
+pub struct BoundMorphism<C: Category> {
     inner: C::Morphism,
 }
 
-impl<C: Category> Morphism<C> {
+impl<C: Category> BoundMorphism<C> {
     /// Wrap a relationship in its category context.
     pub fn of(m: C::Morphism) -> Self {
         Self { inner: m }
@@ -66,7 +66,7 @@ impl<C: Category> Morphism<C> {
     }
 }
 
-impl<C: Category> PartialEq for Morphism<C>
+impl<C: Category> PartialEq for BoundMorphism<C>
 where
     C::Morphism: PartialEq,
 {
@@ -75,7 +75,7 @@ where
     }
 }
 
-impl<C: Category> Eq for Morphism<C> where C::Morphism: Eq {}
+impl<C: Category> Eq for BoundMorphism<C> where C::Morphism: Eq {}
 
 /// Compose a sequence of morphisms left to right.
 ///
@@ -83,22 +83,23 @@ impl<C: Category> Eq for Morphism<C> where C::Morphism: Eq {}
 /// let path = compose_all::<MyCat>(&[f, g, h]);
 /// // equivalent to: f.then(g).then(h)
 /// ```
-pub fn compose_all<C: Category>(morphisms: &[C::Morphism]) -> Option<Morphism<C>>
+pub fn compose_all<C: Category>(morphisms: &[C::Morphism]) -> Option<BoundMorphism<C>>
 where
     C::Morphism: Clone,
 {
     let mut iter = morphisms.iter();
-    let first = Morphism::<C>::of(iter.next()?.clone());
+    let first = BoundMorphism::<C>::of(iter.next()?.clone());
     iter.try_fold(first, |acc, m| acc.then(m))
 }
 
 /// All direct morphisms from `start` to `end` (single-step, not multi-hop).
-pub fn direct_morphisms<C: Category>(start: &C::Object, end: &C::Object) -> Vec<C::Morphism>
+pub fn direct_morphisms<C: Category>(start: &C::Object, end: &C::Object) -> Vec<BoundMorphism<C>>
 where
     C::Object: PartialEq,
 {
     C::morphisms()
         .into_iter()
         .filter(|m| m.source() == *start && m.target() == *end)
+        .map(BoundMorphism::of)
         .collect()
 }


### PR DESCRIPTION
Renamed the categorical functional wrapper `Morphism` to `BoundMorphism` to resolve a naming conflict with the ontological `Morphism` record in `ontology::meta`. Updated call sites, re-exports, and return types for consistency across the category theory utility module.

Fixes #8

---
*PR created automatically by Jules for task [16210272170982720203](https://jules.google.com/task/16210272170982720203) started by @awfmilton*