### PR TITLE
Fix CYK parser for interrogatives and math operators

### DIFF
--- a/crates/chat/src/lib.rs
+++ b/crates/chat/src/lib.rs
@@ -718,6 +718,7 @@ pub fn extract_entity_name(sem: &montague::Sem) -> String {
         montague::Sem::Prop { predicate, .. } | montague::Sem::Question { predicate, .. } => {
             predicate.clone()
         }
+        montague::Sem::Op { word } => word.clone(),
     }
 }
 

--- a/crates/domains/src/cognitive/linguistics/lambek/montague.rs
+++ b/crates/domains/src/cognitive/linguistics/lambek/montague.rs
@@ -36,6 +36,8 @@ pub enum Sem {
     },
     /// Predicate domain (N): a property that can be true of entities.
     Pred { word: String },
+    /// Operator domain (Operator): a mathematical or logical operation.
+    Op { word: String },
     /// Proposition domain (S): a complete truth-evaluable statement.
     Prop {
         predicate: String,
@@ -55,6 +57,7 @@ impl Sem {
         match self {
             Sem::Concept { word, .. } => word.clone(),
             Sem::Pred { word } => format!("λx.{}(x)", word),
+            Sem::Op { word } => word.clone(),
             Sem::Prop {
                 predicate,
                 arguments,
@@ -99,10 +102,17 @@ fn lex(word: &str, ty: &LambekType, en: &English) -> Sem {
         LambekType::Atom(super::types::AtomicType::N) => Sem::Pred { word: word.into() },
         // A/B or A\B → Function domain
         // The function takes a B-domain value and produces an A-domain value
-        LambekType::RightDiv(_, _) | LambekType::LeftDiv(_, _) => Sem::Func {
-            word: word.into(),
-            body: Box::new(Sem::Pred { word: word.into() }),
-        },
+        LambekType::RightDiv(_, _) | LambekType::LeftDiv(_, _) => {
+            // Handle Operators separately in the lexicon mapping
+            if word == "+" || word == "-" || word == "*" || word == "/" || word == "=" {
+                Sem::Op { word: word.into() }
+            } else {
+                Sem::Func {
+                    word: word.into(),
+                    body: Box::new(Sem::Pred { word: word.into() }),
+                }
+            }
+        }
         // S or other atoms — predicate as default
         _ => Sem::Pred { word: word.into() },
     }
@@ -156,6 +166,15 @@ pub fn interpret(tokens: &[TypedToken], en: &English) -> Sem {
 /// When types reduce via A/B + B → A, the semantics is f(x).
 /// The result domain is determined by the result type.
 fn apply(func: &Sem, arg: &Sem, result_type: &LambekType) -> Sem {
+    // Special case: infix operators (N\N)/N
+    // If func is Op or a partial Op, build a Prop/Question
+    if let Sem::Op { word } = func {
+        return Sem::Func {
+            word: word.clone(),
+            body: Box::new(arg.clone()),
+        };
+    }
+
     match result_type {
         // Result is S (any feature) — check if question or proposition
         LambekType::Atom(super::types::AtomicType::S(feature)) => {
@@ -185,6 +204,15 @@ fn apply(func: &Sem, arg: &Sem, result_type: &LambekType) -> Sem {
         },
         // Result is N (predicate) — modifier applied to predicate
         LambekType::Atom(super::types::AtomicType::N) => {
+            if let Sem::Func { word, body } = func {
+                 // Check if it's a partial operator (e.g., "+ 2")
+                 // Type is N\N, applied to N
+                 return Sem::Prop {
+                     predicate: word.clone(),
+                     arguments: vec![*body.clone(), arg.clone()],
+                 };
+            }
+
             let func_word = extract_word(func);
             let arg_word = extract_word(arg);
             Sem::Pred {
@@ -206,6 +234,7 @@ fn apply(func: &Sem, arg: &Sem, result_type: &LambekType) -> Sem {
 fn extract_predicate(sem: &Sem) -> String {
     match sem {
         Sem::Pred { word } => word.clone(),
+        Sem::Op { word } => word.clone(),
         Sem::Func { word, .. } => word.clone(),
         Sem::Concept { word, .. } => word.clone(),
         Sem::Prop { predicate, .. } | Sem::Question { predicate, .. } => predicate.clone(),
@@ -215,6 +244,7 @@ fn extract_predicate(sem: &Sem) -> String {
 fn extract_word(sem: &Sem) -> String {
     match sem {
         Sem::Pred { word } => word.clone(),
+        Sem::Op { word } => word.clone(),
         Sem::Func { word, .. } => word.clone(),
         Sem::Concept { word, .. } => word.clone(),
         Sem::Prop { predicate, .. } | Sem::Question { predicate, .. } => predicate.clone(),

--- a/crates/domains/src/cognitive/linguistics/lambek/tokenize.rs
+++ b/crates/domains/src/cognitive/linguistics/lambek/tokenize.rs
@@ -5,6 +5,7 @@ use super::reduce::TypedToken;
 use super::types::LambekType;
 use super::types::svo as svo_types;
 use crate::cognitive::linguistics::language::Language;
+use crate::cognitive::linguistics::lexicon::pos::LexicalEntry;
 use crate::cognitive::linguistics::lemon::lexicon::ConceptRef;
 use crate::cognitive::linguistics::orthography::distance;
 use crate::cognitive::linguistics::text::Token;
@@ -21,7 +22,7 @@ use pr4xis::category::entity::Concept;
 pub fn tokenize(text: &str, language: &dyn Language) -> Vec<TypedToken> {
     let cleaned = text
         .trim()
-        .trim_end_matches(|c: char| c.is_ascii_punctuation());
+        .trim_end_matches(|c: char| c.is_ascii_punctuation() && !is_math_operator(c));
 
     let words: Vec<&str> = cleaned.split_whitespace().collect();
 
@@ -29,7 +30,7 @@ pub fn tokenize(text: &str, language: &dyn Language) -> Vec<TypedToken> {
         .iter()
         .enumerate()
         .filter_map(|(i, word)| {
-            let word_clean = word.trim_matches(|c: char| c.is_ascii_punctuation());
+            let word_clean = word.trim_matches(|c: char| c.is_ascii_punctuation() && !is_math_operator(c));
             if word_clean.is_empty() {
                 return None;
             }
@@ -56,7 +57,7 @@ pub fn tokenize_with_alternatives(
 ) -> (Vec<TypedToken>, Vec<Vec<LambekType>>) {
     let cleaned = text
         .trim()
-        .trim_end_matches(|c: char| c.is_ascii_punctuation());
+        .trim_end_matches(|c: char| c.is_ascii_punctuation() && !is_math_operator(c));
 
     let words: Vec<&str> = cleaned.split_whitespace().collect();
 
@@ -64,7 +65,7 @@ pub fn tokenize_with_alternatives(
     let mut alternatives = Vec::new();
 
     for (i, word) in words.iter().enumerate() {
-        let word_clean = word.trim_matches(|c: char| c.is_ascii_punctuation());
+        let word_clean = word.trim_matches(|c: char| c.is_ascii_punctuation() && !is_math_operator(c));
         if word_clean.is_empty() {
             continue;
         }
@@ -104,7 +105,7 @@ pub fn tokenize_with_alternatives(
 pub fn tokenize_ontological(text: &str, language: &dyn Language) -> Vec<Token> {
     let cleaned = text
         .trim()
-        .trim_end_matches(|c: char| c.is_ascii_punctuation());
+        .trim_end_matches(|c: char| c.is_ascii_punctuation() && !is_math_operator(c));
 
     let words: Vec<&str> = cleaned.split_whitespace().collect();
 
@@ -112,7 +113,7 @@ pub fn tokenize_ontological(text: &str, language: &dyn Language) -> Vec<Token> {
         .iter()
         .enumerate()
         .filter_map(|(i, word)| {
-            let word_clean = word.trim_matches(|c: char| c.is_ascii_punctuation());
+            let word_clean = word.trim_matches(|c: char| c.is_ascii_punctuation() && !is_math_operator(c));
             if word_clean.is_empty() {
                 return None;
             }
@@ -167,9 +168,16 @@ fn assign_type(word: &str, position: usize, language: &dyn Language) -> LambekTy
             return svo_types::question_copula();
         }
 
-        // Interrogative pronouns at sentence start → wh-question type
-        if first.is_some_and(|e| e.is_interrogative()) {
-            return svo_types::wh_what();
+        // Interrogative words at sentence start → wh-question type
+        if let Some(e) = first {
+            if e.is_interrogative() {
+                // If it's a determiner like "what", check if it's followed by a noun
+                // "what dog" (interrogative determiner) vs "what is" (interrogative pronoun)
+                if matches!(e, LexicalEntry::Determiner(_)) {
+                    return svo_types::interrogative_determiner();
+                }
+                return svo_types::wh_what();
+            }
         }
     }
 
@@ -207,6 +215,12 @@ fn select_best_entry(
 /// Noisy channel adjunction: Observation → Correction → Intention.
 /// Given an unknown word, find the closest known word and use its type.
 fn try_spelling_correction(word: &str, language: &dyn Language) -> Option<LambekType> {
+    // Skip numeric strings and very short symbols — these shouldn't be "corrected"
+    // to function words (e.g., "2" should NOT become "a").
+    if word.chars().all(|c| c.is_numeric() || is_math_operator(c)) || word.len() < 2 {
+        return None;
+    }
+
     let known = language.known_words();
     let matches = distance::closest_matches(word, &known, 1);
     if let Some((corrected, _)) = matches.first()
@@ -215,6 +229,10 @@ fn try_spelling_correction(word: &str, language: &dyn Language) -> Option<Lambek
         return Some(pos_to_lambek(&entry));
     }
     None
+}
+
+fn is_math_operator(c: char) -> bool {
+    matches!(c, '+' | '-' | '*' | '/' | '=' | '<' | '>' | '%' | '^')
 }
 
 /// Post-processing: when copula is followed by adjective, reassign types.
@@ -251,5 +269,6 @@ fn pos_to_lambek(entry: &crate::cognitive::linguistics::lexicon::pos::LexicalEnt
         LexicalEntry::Auxiliary(_) => svo_types::intransitive_verb(),
         LexicalEntry::Interjection(_) => svo_types::noun(),
         LexicalEntry::Particle(_) => svo_types::adverb(),
+        LexicalEntry::Operator(_) => svo_types::infix_operator(),
     }
 }

--- a/crates/domains/src/cognitive/linguistics/lambek/types.rs
+++ b/crates/domains/src/cognitive/linguistics/lambek/types.rs
@@ -367,4 +367,15 @@ pub mod svo {
             LambekType::left_div(LambekType::np(), LambekType::s()),
         )
     }
+
+    /// Interrogative determiner: (S[wq]/(S\NP))/N — "what dog is big?"
+    /// Or simpler: NP[wq]/N — "what dog"
+    pub fn interrogative_determiner() -> LambekType {
+        LambekType::right_div(LambekType::np(), LambekType::n())
+    }
+
+    /// Infix operator (for math): (N\N)/N — "2 + 2"
+    pub fn infix_operator() -> LambekType {
+        LambekType::right_div(LambekType::left_div(LambekType::n(), LambekType::n()), LambekType::n())
+    }
 }

--- a/crates/domains/src/cognitive/linguistics/language.rs
+++ b/crates/domains/src/cognitive/linguistics/language.rs
@@ -367,6 +367,15 @@ pub fn lexical_entry_to_pregroup(entry: &LexicalEntry) -> PregroupType {
             ])
         }
         LexicalEntry::Numeral(_) => pregroup::svo::determiner(),
+        LexicalEntry::Operator(_) => {
+            // (np^r · s)^r · np^r · s (like adverb but infix)
+            // Simplified: s · s^l · s^l
+            PregroupType::new(vec![
+                pregroup::PregroupElement::basic(pregroup::BasicType::S),
+                pregroup::PregroupElement::left_adj(pregroup::BasicType::S),
+                pregroup::PregroupElement::left_adj(pregroup::BasicType::S),
+            ])
+        }
     }
 }
 
@@ -626,6 +635,22 @@ fn build_english_function_words_embedded() -> HashMap<String, Vec<LexicalEntry>>
         }));
     }
 
+    // Interrogative Determiners (for "what dog", "which mammal")
+    for text in ["what", "which"] {
+        add(LexicalEntry::Determiner(Determiner {
+            text: text.into(),
+            definiteness: Definiteness::Indefinite,
+            number: None,
+        }));
+    }
+
+    // Interrogative Adverbs (OLiA: InterrogativeAdverb)
+    for text in ["how", "where", "why", "when"] {
+        add(LexicalEntry::Adverb(Adverb {
+            text: text.into(),
+        }));
+    }
+
     // ---- Prepositions (OLiA: Preposition) ----
     for text in [
         "in", "on", "at", "with", "to", "from", "by", "for", "of", "about", "into", "through",
@@ -644,6 +669,13 @@ fn build_english_function_words_embedded() -> HashMap<String, Vec<LexicalEntry>>
     // ---- Particles (OLiA: Particle) ----
     for text in ["not", "to"] {
         add(LexicalEntry::Particle(Particle { text: text.into() }));
+    }
+
+    // ---- Operators (OLiA: Operator) ----
+    for text in ["+", "-", "*", "/", "=", "<", ">", "%", "^"] {
+        add(LexicalEntry::Operator(Operator {
+            text: text.into(),
+        }));
     }
 
     // ---- Interjections (OLiA: Interjection) — classified by function ----

--- a/crates/domains/src/cognitive/linguistics/lexicon/olia.rs
+++ b/crates/domains/src/cognitive/linguistics/lexicon/olia.rs
@@ -124,6 +124,9 @@ fn from_fragment(fragment: &str) -> Option<PosTag> {
         | "MultiplicativeNumeral"
         | "CollectiveNumeral" => Some(PosTag::Numeral),
 
+        // Operator
+        "Operator" => Some(PosTag::Operator),
+
         _ => None,
     }
 }
@@ -164,5 +167,6 @@ pub fn pos_to_olia_fragments(pos: PosTag) -> Vec<&'static str> {
         PosTag::Interjection => vec!["Interjection"],
         PosTag::Particle => vec!["Particle", "NegativeParticle", "InfinitiveParticle"],
         PosTag::Numeral => vec!["Numeral", "CardinalNumber", "OrdinalNumber"],
+        PosTag::Operator => vec!["Operator"],
     }
 }

--- a/crates/domains/src/cognitive/linguistics/lexicon/pos.rs
+++ b/crates/domains/src/cognitive/linguistics/lexicon/pos.rs
@@ -193,6 +193,12 @@ pub struct Numeral {
     pub text: String,
 }
 
+/// A mathematical operator: "+", "-", "*", "/", "=", "<", ">".
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Operator {
+    pub text: String,
+}
+
 /// A lexical entry — a word with its full part-of-speech structure.
 /// Each variant carries the rich type for that part of speech.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -210,6 +216,7 @@ pub enum LexicalEntry {
     Interjection(Interjection),
     Particle(Particle),
     Numeral(Numeral),
+    Operator(Operator),
 }
 
 impl LexicalEntry {
@@ -228,6 +235,7 @@ impl LexicalEntry {
             Self::Interjection(i) => &i.text,
             Self::Particle(p) => &p.text,
             Self::Numeral(n) => &n.text,
+            Self::Operator(o) => &o.text,
         }
     }
 
@@ -271,11 +279,13 @@ impl LexicalEntry {
         }
     }
 
-    /// Is this an interrogative pronoun?
-    /// Determined by the OLiA classification, not by the word itself.
+    /// Is this an interrogative word?
+    /// Determined by the OLiA classification or common wh-words.
     pub fn is_interrogative(&self) -> bool {
         match self {
             Self::Pronoun(p) => p.kind == PronounKind::Interrogative,
+            Self::Adverb(a) => matches!(a.text.as_str(), "how" | "where" | "why" | "when"),
+            Self::Determiner(d) => matches!(d.text.as_str(), "what" | "which"),
             _ => false,
         }
     }
@@ -295,6 +305,7 @@ impl LexicalEntry {
             Self::Interjection(_) => PosTag::Interjection,
             Self::Particle(_) => PosTag::Particle,
             Self::Numeral(_) => PosTag::Numeral,
+            Self::Operator(_) => PosTag::Operator,
         }
     }
 }
@@ -326,6 +337,8 @@ pub enum PosTag {
     Particle,
     /// OLiA: Numeral — number words ("one", "two", "first").
     Numeral,
+    /// OLiA: Operator — mathematical and logical operators ("+", "-", "=", ">").
+    Operator,
 }
 
 impl PosTag {

--- a/crates/domains/src/formal/information/diagnostics/trace_impls.rs
+++ b/crates/domains/src/formal/information/diagnostics/trace_impls.rs
@@ -101,6 +101,7 @@ impl Traceable for InterpretResult<'_> {
             }
             Sem::Concept { word, .. } => format!("entity: {word}"),
             Sem::Pred { word } => format!("concept: {word}"),
+            Sem::Op { word } => format!("operator: {word}"),
             Sem::Func { word, .. } => format!("function: {word}"),
         }
     }


### PR DESCRIPTION
Fixed tokenizer and parser issues for mathematical operators and interrogative sentences. Expanded the lexicon and improved semantic interpretation for infix operations.

Fixes #6

---
*PR created automatically by Jules for task [4556367392064555005](https://jules.google.com/task/4556367392064555005) started by @awfmilton*