### PR TITLE
Design code-emission abstraction with HTML as first target

### DIFF
--- a/crates/domains/Cargo.toml
+++ b/crates/domains/Cargo.toml
@@ -32,6 +32,7 @@ default = ["std"]
 # loader). The categorical stack (ontologies + functors + axioms) runs
 # no_std + alloc; per issue #91, only these 4 I/O surfaces need std.
 std = ["pr4xis/std"]
+codegen = ["pr4xis/codegen"]
 fetch = ["std", "dep:ureq", "dep:flate2"]
 
 [lints]

--- a/crates/domains/src/social/software/markup/emit.rs
+++ b/crates/domains/src/social/software/markup/emit.rs
@@ -1,0 +1,89 @@
+use alloc::format;
+use alloc::string::String;
+use pr4xis::codegen::Emit;
+
+use super::ontology::{MarkupNode, NodeKind};
+
+/// HTML emission target marker.
+pub struct Html;
+
+impl Emit<Html> for MarkupNode {
+    fn emit(&self) -> String {
+        match self.kind {
+            NodeKind::Document => {
+                let mut out = String::new();
+                for child in &self.children {
+                    out.push_str(&Emit::<Html>::emit(child));
+                }
+                out
+            }
+            NodeKind::Element => {
+                let name = self.name.as_deref().unwrap_or("div");
+                let mut out = format!("<{}", name);
+
+                for (k, v) in &self.attributes {
+                    out.push_str(&format!(" {}=\"{}\"", k, escape_html(v)));
+                }
+
+                if is_void_element(name) {
+                    out.push_str(" />");
+                } else {
+                    out.push('>');
+                    for child in &self.children {
+                        out.push_str(&Emit::<Html>::emit(child));
+                    }
+                    out.push_str(&format!("</{}>", name));
+                }
+                out
+            }
+            NodeKind::Text => escape_html(self.value.as_deref().unwrap_or("")),
+            NodeKind::Comment => {
+                format!("<!-- {} -->", self.value.as_deref().unwrap_or(""))
+            }
+            NodeKind::ProcessingInstruction => {
+                let name = self.name.as_deref().unwrap_or("");
+                if name.to_lowercase() == "doctype" {
+                    format!("<!DOCTYPE {}>", self.value.as_deref().unwrap_or("html"))
+                } else {
+                    format!("<?{} {}?>", name, self.value.as_deref().unwrap_or(""))
+                }
+            }
+            NodeKind::Attribute => String::new(), // Attributes are handled in Element
+        }
+    }
+}
+
+fn escape_html(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+fn is_void_element(name: &str) -> bool {
+    matches!(
+        name.to_lowercase().as_str(),
+        "area"
+            | "base"
+            | "br"
+            | "col"
+            | "embed"
+            | "hr"
+            | "img"
+            | "input"
+            | "link"
+            | "meta"
+            | "param"
+            | "source"
+            | "track"
+            | "wbr"
+    )
+}

--- a/crates/domains/src/social/software/markup/mod.rs
+++ b/crates/domains/src/social/software/markup/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "codegen")]
+pub mod emit;
 pub mod ontology;
 pub mod xml;
 

--- a/crates/domains/src/social/software/markup/tests.rs
+++ b/crates/domains/src/social/software/markup/tests.rs
@@ -132,6 +132,79 @@ fn comment_is_preserved() {
     assert_eq!(node.value.as_deref(), Some("this is a comment"));
 }
 
+#[cfg(feature = "codegen")]
+mod emission {
+    use super::*;
+    use crate::social::software::markup::emit::Html;
+    use pr4xis::codegen::Emit;
+
+    #[test]
+    fn emit_simple_html() {
+        let node = MarkupNode::element(
+            "div",
+            vec![("class", "foo")],
+            vec![
+                MarkupNode::text("hello"),
+                MarkupNode::element("span", vec![], vec![MarkupNode::text("world")]),
+            ],
+        );
+        let html = Emit::<Html>::emit(&node);
+        assert_eq!(html, "<div class=\"foo\">hello<span>world</span></div>");
+    }
+
+    #[test]
+    fn emit_void_element() {
+        let node = MarkupNode::element("img", vec![("src", "foo.png")], vec![]);
+        let html = Emit::<Html>::emit(&node);
+        assert_eq!(html, "<img src=\"foo.png\" />");
+    }
+
+    #[test]
+    fn emit_escaping() {
+        let node = MarkupNode::element(
+            "p",
+            vec![("title", "a & b")],
+            vec![MarkupNode::text("<script>alert('hi')</script>")],
+        );
+        let html = Emit::<Html>::emit(&node);
+        assert_eq!(
+            html,
+            "<p title=\"a &amp; b\">&lt;script&gt;alert(&#39;hi&#39;)&lt;/script&gt;</p>"
+        );
+    }
+
+    #[test]
+    fn emit_document_with_doctype() {
+        let doc = MarkupNode::document(vec![
+            MarkupNode {
+                kind: NodeKind::ProcessingInstruction,
+                name: Some("doctype".into()),
+                value: Some("html".into()),
+                attributes: vec![],
+                children: vec![],
+            },
+            MarkupNode::element(
+                "html",
+                vec![],
+                vec![MarkupNode::element(
+                    "body",
+                    vec![],
+                    vec![MarkupNode::text("hi")],
+                )],
+            ),
+        ]);
+        let html = Emit::<Html>::emit(&doc);
+        assert_eq!(html, "<!DOCTYPE html><html><body>hi</body></html>");
+    }
+
+    #[test]
+    fn emit_comment() {
+        let node = MarkupNode::comment("secret");
+        let html = Emit::<Html>::emit(&node);
+        assert_eq!(html, "<!-- secret -->");
+    }
+}
+
 use pr4xis::category::Category;
 
 // =============================================================================

--- a/crates/pr4xis/Cargo.toml
+++ b/crates/pr4xis/Cargo.toml
@@ -12,14 +12,14 @@ keywords = ["ontology", "category-theory", "enforcement", "state-machine", "form
 [features]
 default = ["std"]
 std = []
-codegen = ["std", "dep:quick-xml"]
+codegen = ["dep:quick-xml"]
 
 [dependencies]
 hashbrown = { version = "0.15", default-features = false, features = ["default-hasher"] }
 linkme = "0.3"
 paste = "1"
 pr4xis-derive = { version = "0.1.0", path = "../pr4xis-derive" }
-quick-xml = { version = "0.37", features = ["serialize"], optional = true }
+quick-xml = { version = "0.37", default-features = false, features = ["serialize"], optional = true }
 
 [lints]
 workspace = true

--- a/crates/pr4xis/src/codegen/emit.rs
+++ b/crates/pr4xis/src/codegen/emit.rs
@@ -1,0 +1,17 @@
+use alloc::string::String;
+use core::marker::PhantomData;
+
+/// Formal abstraction for translating validated ontological structures into target-language syntax.
+///
+/// Targets are implemented as marker structs to allow a single type to implement
+/// emission for multiple backends (e.g., HTML, SQL, Rust).
+pub trait Emit<Target> {
+    /// Emit the structure as a string for the specified target.
+    fn emit(&self) -> String;
+}
+
+/// A marker for types that can be emitted.
+pub struct Emitter<T, Target> {
+    _data: PhantomData<T>,
+    _target: PhantomData<Target>,
+}

--- a/crates/pr4xis/src/codegen/mod.rs
+++ b/crates/pr4xis/src/codegen/mod.rs
@@ -1,8 +1,15 @@
+#[cfg(feature = "std")]
 mod builder;
+pub mod emit;
+#[cfg(feature = "std")]
 mod generate;
+#[cfg(feature = "std")]
 pub mod wordnet;
 
+#[cfg(feature = "std")]
 pub use builder::{EntityDef, GenerateConfig, OntologyBuilder};
+pub use emit::Emit;
+#[cfg(feature = "std")]
 pub use generate::generate_rust;
 
 // Re-export CodegenData from the always-available module.


### PR DESCRIPTION
This change introduces a formal code-emission abstraction in the `pr4xis` core and provides a first concrete implementation for HTML in the `domains` crate.

The `Emit<Target>` trait uses marker structs (like `Html`) to allow a single type to implement emission for multiple backends. The abstraction is designed to be `no_std + alloc` compatible, enabling code generation in restricted environments.

In the `domains` crate, the existing `MarkupNode` ontology now implements `Emit<Html>`, supporting:
- Nested document and element structures.
- Attribute emission with proper HTML escaping.
- Handling of HTML5 void elements (e.g., `<img>`, `<br>`).
- DOCTYPE declarations via `ProcessingInstruction` nodes.
- HTML comments.

The `codegen` feature in `pr4xis` has been adjusted to no longer strictly depend on `std`, although `std`-dependent utilities like `OntologyBuilder` remain gated. `quick-xml` is now used with `default-features = false` to preserve the `no_std` discipline.

Fixes #2

---
*PR created automatically by Jules for task [13804365679285294026](https://jules.google.com/task/13804365679285294026) started by @awfmilton*