### PR TITLE
fix: CYK chart_reduce preserves question features instead of dropping them

### DIFF
--- a/crates/domains/src/cognitive/linguistics/lambek/reduce.rs
+++ b/crates/domains/src/cognitive/linguistics/lambek/reduce.rs
@@ -176,8 +176,10 @@ pub fn chart_reduce(words: &[String], type_sets: &[Vec<LambekType>]) -> Reductio
         .iter()
         .filter(|t| matches!(t, LambekType::Atom(super::types::AtomicType::S(_))))
         .max_by_key(|t| match t {
-            LambekType::Atom(super::types::AtomicType::S(Some(_))) => 1,
-            _ => 0,
+            LambekType::Atom(super::types::AtomicType::S(Some(super::types::SentenceFeature::Q))) => 3,
+            LambekType::Atom(super::types::AtomicType::S(Some(super::types::SentenceFeature::Wq))) => 3,
+            LambekType::Atom(super::types::AtomicType::S(Some(_))) => 2,
+            _ => 1,
         });
 
     let success = sentence_type.is_some();

--- a/crates/domains/src/cognitive/linguistics/lambek/tests.rs
+++ b/crates/domains/src/cognitive/linguistics/lambek/tests.rs
@@ -516,3 +516,40 @@ fn montague_describe() {
     // Should be something like "runs(dog)" or "runs(dog, ...)"
     assert!(!desc.is_empty());
 }
+
+#[test]
+fn chart_reduce_prefers_question_over_declarative() {
+    let words = vec!["test".to_string()];
+    // S[dcl] and S[q]
+    // We try many combinations to see if any of them favor S[dcl]
+    let type_sets = vec![vec![LambekType::s_dcl(), LambekType::q()]];
+    let result = chart_reduce(&words, &type_sets);
+    assert!(result.success);
+    assert_eq!(result.final_type, Some(LambekType::q()), "Should prefer S[q] over S[dcl]");
+}
+
+#[test]
+fn chart_reduce_full_priority() {
+    let words = vec!["test".to_string()];
+
+    // S[q] vs S[dcl] -> S[q]
+    let type_sets = vec![vec![LambekType::s_dcl(), LambekType::q()]];
+    let result = chart_reduce(&words, &type_sets);
+    assert_eq!(result.final_type, Some(LambekType::q()));
+
+    // S[wq] vs S[dcl] -> S[wq]
+    let type_sets = vec![vec![LambekType::s_dcl(), LambekType::wq()]];
+    let result = chart_reduce(&words, &type_sets);
+    assert_eq!(result.final_type, Some(LambekType::wq()));
+
+    // S[dcl] vs S -> S[dcl]
+    let type_sets = vec![vec![LambekType::s(), LambekType::s_dcl()]];
+    let result = chart_reduce(&words, &type_sets);
+    assert_eq!(result.final_type, Some(LambekType::s_dcl()));
+
+    // S[q] vs S[wq] -> Both are priority 3, so one will be picked.
+    let type_sets = vec![vec![LambekType::q(), LambekType::wq()]];
+    let result = chart_reduce(&words, &type_sets);
+    let ft = result.final_type.unwrap();
+    assert!(ft == LambekType::q() || ft == LambekType::wq());
+}


### PR DESCRIPTION
This PR fixes a bug in the Lambek CYK parser where question features were lost due to arbitrary selection among valid sentence types. I've implemented a tiered priority system that favors S[q] and S[wq] over other sentence types and added unit tests to ensure correct behavior.

Fixes #28

---
*PR created automatically by Jules for task [3875218215876269667](https://jules.google.com/task/3875218215876269667) started by @awfmilton*