### PR TITLE
fix(PHASE 2): Tokenizer adds missing interrogative adverbs and pronouns to lexicon

### DIFF
--- a/crates/domains/src/cognitive/linguistics/lambek/reduce.rs
+++ b/crates/domains/src/cognitive/linguistics/lambek/reduce.rs
@@ -176,8 +176,12 @@ pub fn chart_reduce(words: &[String], type_sets: &[Vec<LambekType>]) -> Reductio
         .iter()
         .filter(|t| matches!(t, LambekType::Atom(super::types::AtomicType::S(_))))
         .max_by_key(|t| match t {
-            LambekType::Atom(super::types::AtomicType::S(Some(super::types::SentenceFeature::Q))) => 3,
-            LambekType::Atom(super::types::AtomicType::S(Some(super::types::SentenceFeature::Wq))) => 3,
+            LambekType::Atom(super::types::AtomicType::S(Some(
+                super::types::SentenceFeature::Q,
+            ))) => 3,
+            LambekType::Atom(super::types::AtomicType::S(Some(
+                super::types::SentenceFeature::Wq,
+            ))) => 3,
             LambekType::Atom(super::types::AtomicType::S(Some(_))) => 2,
             _ => 1,
         });

--- a/crates/domains/src/cognitive/linguistics/lambek/tests.rs
+++ b/crates/domains/src/cognitive/linguistics/lambek/tests.rs
@@ -283,6 +283,36 @@ fn what_is_a_dog() {
     assert_eq!(tokens[0].lambek_type, svo::wh_what()); // what
 }
 
+#[test]
+fn interrogative_adverbs_tokenize() {
+    let lang = sample_lang();
+    for word in ["how", "why", "where", "when"] {
+        let text = format!("{} are you", word);
+        let tokens = tokenize::tokenize(&text, &lang);
+        assert_eq!(
+            tokens[0].lambek_type,
+            svo::wh_what(),
+            "word '{}' should be tokenized as wh_what",
+            word
+        );
+    }
+}
+
+#[test]
+fn interrogative_pronouns_tokenize() {
+    let lang = sample_lang();
+    for word in ["whom", "whose"] {
+        let text = format!("{} is this", word);
+        let tokens = tokenize::tokenize(&text, &lang);
+        assert_eq!(
+            tokens[0].lambek_type,
+            svo::wh_what(),
+            "word '{}' should be tokenized as wh_what",
+            word
+        );
+    }
+}
+
 // =============================================================================
 // Type notation tests
 // =============================================================================
@@ -525,7 +555,11 @@ fn chart_reduce_prefers_question_over_declarative() {
     let type_sets = vec![vec![LambekType::s_dcl(), LambekType::q()]];
     let result = chart_reduce(&words, &type_sets);
     assert!(result.success);
-    assert_eq!(result.final_type, Some(LambekType::q()), "Should prefer S[q] over S[dcl]");
+    assert_eq!(
+        result.final_type,
+        Some(LambekType::q()),
+        "Should prefer S[q] over S[dcl]"
+    );
 }
 
 #[test]

--- a/crates/domains/src/cognitive/linguistics/lambek/tokenize.rs
+++ b/crates/domains/src/cognitive/linguistics/lambek/tokenize.rs
@@ -167,8 +167,8 @@ fn assign_type(word: &str, position: usize, language: &dyn Language) -> LambekTy
             return svo_types::question_copula();
         }
 
-        // Interrogative pronouns at sentence start → wh-question type
-        if first.is_some_and(|e| e.is_interrogative()) {
+        // Interrogative pronouns/adverbs at sentence start → wh-question type
+        if entries.iter().any(|e| e.is_interrogative()) {
             return svo_types::wh_what();
         }
     }

--- a/crates/domains/src/cognitive/linguistics/language.rs
+++ b/crates/domains/src/cognitive/linguistics/language.rs
@@ -248,7 +248,10 @@ pub fn lmf_pos_to_lexical_entries(
             }
         }
         lmf::LmfPos::Adjective => vec![LexicalEntry::Adjective(Adjective { text: word.into() })],
-        lmf::LmfPos::Adverb => vec![LexicalEntry::Adverb(Adverb { text: word.into() })],
+        lmf::LmfPos::Adverb => vec![LexicalEntry::Adverb(Adverb {
+            text: word.into(),
+            interrogative: false,
+        })],
         lmf::LmfPos::Determiner | lmf::LmfPos::Numeral => {
             vec![LexicalEntry::Determiner(Determiner {
                 text: word.into(),
@@ -617,12 +620,20 @@ fn build_english_function_words_embedded() -> HashMap<String, Vec<LexicalEntry>>
     }
 
     // ---- Interrogative Pronouns (OLiA: InterrogativePronoun) ----
-    for text in ["what", "who", "which"] {
+    for text in ["what", "who", "which", "whom", "whose"] {
         add(LexicalEntry::Pronoun(Pronoun {
             text: text.into(),
             number: Number::Singular,
             person: Person::Third,
             kind: PronounKind::Interrogative,
+        }));
+    }
+
+    // ---- Interrogative Adverbs ----
+    for text in ["how", "why", "where", "when"] {
+        add(LexicalEntry::Adverb(Adverb {
+            text: text.into(),
+            interrogative: true,
         }));
     }
 
@@ -636,7 +647,7 @@ fn build_english_function_words_embedded() -> HashMap<String, Vec<LexicalEntry>>
 
     // ---- Conjunctions (OLiA: Conjunction) ----
     for text in [
-        "and", "but", "or", "so", "yet", "nor", "because", "although", "if", "when",
+        "and", "but", "or", "so", "yet", "nor", "because", "although", "if",
     ] {
         add(LexicalEntry::Conjunction(Conjunction { text: text.into() }));
     }

--- a/crates/domains/src/cognitive/linguistics/lexicon/pos.rs
+++ b/crates/domains/src/cognitive/linguistics/lexicon/pos.rs
@@ -96,6 +96,7 @@ pub struct Adjective {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Adverb {
     pub text: String,
+    pub interrogative: bool,
 }
 
 /// A preposition: "in", "on", "with".
@@ -271,11 +272,12 @@ impl LexicalEntry {
         }
     }
 
-    /// Is this an interrogative pronoun?
+    /// Is this an interrogative pronoun or adverb?
     /// Determined by the OLiA classification, not by the word itself.
     pub fn is_interrogative(&self) -> bool {
         match self {
             Self::Pronoun(p) => p.kind == PronounKind::Interrogative,
+            Self::Adverb(a) => a.interrogative,
             _ => false,
         }
     }

--- a/crates/domains/src/social/software/markup/mod.rs
+++ b/crates/domains/src/social/software/markup/mod.rs
@@ -1,6 +1,6 @@
-pub mod html;
 #[cfg(feature = "codegen")]
 pub mod emit;
+pub mod html;
 pub mod ontology;
 pub mod xml;
 


### PR DESCRIPTION
This PR completes Phase 2 of the CYK parser improvements by extending the lexicon and tokenizer to correctly handle interrogative adverbs and pronouns.

Key changes:
1.  **Lexicon Extensions**: The `Adverb` struct now includes an `interrogative` flag, and `LexicalEntry::is_interrogative` has been generalized to check both pronouns and adverbs.
2.  **Embedded Lexicon Update**: Added missing interrogative words ("whom", "whose", "how", "why", "where", "when") to the English embedded lexicon. "When" was moved from Conjunctions to Adverbs to support its role in wh-questions.
3.  **Tokenizer Improvement**: The tokenizer now checks all possible lexical entries for a word at the start of a sentence to determine if it's interrogative, ensuring robust `wh_what` type assignment.
4.  **Verification**: Added targeted unit tests to verify that all new interrogative words are correctly identified and typed during tokenization.

All changes pass `cargo check`, `cargo clippy`, and `cargo fmt`.

Fixes #30

---
*PR created automatically by Jules for task [13372174728407276883](https://jules.google.com/task/13372174728407276883) started by @awfmilton*