### PR TITLE
fix(PHASE 3a): Add Operator struct and PosTag to pos.rs

### DIFF
--- a/crates/domains/src/cognitive/linguistics/lambek/tokenize.rs
+++ b/crates/domains/src/cognitive/linguistics/lambek/tokenize.rs
@@ -251,5 +251,6 @@ fn pos_to_lambek(entry: &crate::cognitive::linguistics::lexicon::pos::LexicalEnt
         LexicalEntry::Auxiliary(_) => svo_types::intransitive_verb(),
         LexicalEntry::Interjection(_) => svo_types::noun(),
         LexicalEntry::Particle(_) => svo_types::adverb(),
+        LexicalEntry::Operator(_) => LambekType::s(), // Placeholder for now
     }
 }

--- a/crates/domains/src/cognitive/linguistics/language.rs
+++ b/crates/domains/src/cognitive/linguistics/language.rs
@@ -272,6 +272,20 @@ pub fn lmf_pos_to_lexical_entries(
             vec![LexicalEntry::Conjunction(Conjunction { text: word.into() })]
         }
         lmf::LmfPos::Particle => vec![LexicalEntry::Particle(Particle { text: word.into() })],
+        lmf::LmfPos::Other => {
+            // Check for operator characters
+            if word.chars().all(|c| "+-*/=<>>".contains(c)) && !word.is_empty() {
+                vec![LexicalEntry::Operator(Operator { text: word.into() })]
+            } else {
+                vec![LexicalEntry::Noun(Noun {
+                    text: word.into(),
+                    number: Number::Singular,
+                    person: Person::Third,
+                    countability: Countability::Countable,
+                    kind: NounKind::Common,
+                })]
+            }
+        }
         lmf::LmfPos::Copula => vec![LexicalEntry::Copula(Copula {
             text: word.into(),
             number: Number::Singular,
@@ -288,13 +302,6 @@ pub fn lmf_pos_to_lexical_entries(
         lmf::LmfPos::Interjection => vec![LexicalEntry::Interjection(Interjection {
             text: word.into(),
             kind: InterjectionKind::Expressive,
-        })],
-        lmf::LmfPos::Other => vec![LexicalEntry::Noun(Noun {
-            text: word.into(),
-            number: Number::Singular,
-            person: Person::Third,
-            countability: Countability::Countable,
-            kind: NounKind::Common,
         })],
     }
 }
@@ -370,6 +377,7 @@ pub fn lexical_entry_to_pregroup(entry: &LexicalEntry) -> PregroupType {
             ])
         }
         LexicalEntry::Numeral(_) => pregroup::svo::determiner(),
+        LexicalEntry::Operator(_) => PregroupType::single(BasicType::S), // Placeholder
     }
 }
 

--- a/crates/domains/src/cognitive/linguistics/lexicon/olia.rs
+++ b/crates/domains/src/cognitive/linguistics/lexicon/olia.rs
@@ -164,5 +164,6 @@ pub fn pos_to_olia_fragments(pos: PosTag) -> Vec<&'static str> {
         PosTag::Interjection => vec!["Interjection"],
         PosTag::Particle => vec!["Particle", "NegativeParticle", "InfinitiveParticle"],
         PosTag::Numeral => vec!["Numeral", "CardinalNumber", "OrdinalNumber"],
+        PosTag::Operator => vec!["Operator"],
     }
 }

--- a/crates/domains/src/cognitive/linguistics/lexicon/pos.rs
+++ b/crates/domains/src/cognitive/linguistics/lexicon/pos.rs
@@ -194,6 +194,13 @@ pub struct Numeral {
     pub text: String,
 }
 
+/// A mathematical operator: "+", "-", "*", "/", "=", "<", ">".
+/// OLiA: Operator.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Operator {
+    pub text: String,
+}
+
 /// A lexical entry — a word with its full part-of-speech structure.
 /// Each variant carries the rich type for that part of speech.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -211,6 +218,7 @@ pub enum LexicalEntry {
     Interjection(Interjection),
     Particle(Particle),
     Numeral(Numeral),
+    Operator(Operator),
 }
 
 impl LexicalEntry {
@@ -229,6 +237,7 @@ impl LexicalEntry {
             Self::Interjection(i) => &i.text,
             Self::Particle(p) => &p.text,
             Self::Numeral(n) => &n.text,
+            Self::Operator(o) => &o.text,
         }
     }
 
@@ -297,6 +306,7 @@ impl LexicalEntry {
             Self::Interjection(_) => PosTag::Interjection,
             Self::Particle(_) => PosTag::Particle,
             Self::Numeral(_) => PosTag::Numeral,
+            Self::Operator(_) => PosTag::Operator,
         }
     }
 }
@@ -328,6 +338,8 @@ pub enum PosTag {
     Particle,
     /// OLiA: Numeral — number words ("one", "two", "first").
     Numeral,
+    /// OLiA: Operator — mathematical and logical operators ("+", "-", "=", ">").
+    Operator,
 }
 
 impl PosTag {


### PR DESCRIPTION
This PR implements Phase 3a of the linguistics domain update by adding the `Operator` struct and its corresponding enum variants to the lexicon's part-of-speech model. 

Key changes:
- `crates/domains/src/cognitive/linguistics/lexicon/pos.rs`: Added `Operator` struct and integrated `Operator` into `LexicalEntry` and `PosTag`.
- `crates/domains/src/cognitive/linguistics/lambek/tokenize.rs`: Added match arm for `LexicalEntry::Operator`.
- `crates/domains/src/cognitive/linguistics/language.rs`: Implemented operator detection logic and updated pregroup mapping.
- `crates/domains/src/cognitive/linguistics/lexicon/olia.rs`: Mapped `PosTag::Operator` to the "Operator" OLiA fragment.

This ensures the domain model can represent mathematical and logical operators as first-class lexical citizens.

Fixes #33

---
*PR created automatically by Jules for task [4597611784773316149](https://jules.google.com/task/4597611784773316149) started by @awfmilton*