### PR TITLE
fix(linguistics): remove duplicate Operator definitions

### DIFF
--- a/crates/domains/src/cognitive/linguistics/lambek/tokenize.rs
+++ b/crates/domains/src/cognitive/linguistics/lambek/tokenize.rs
@@ -29,7 +29,8 @@ pub fn tokenize(text: &str, language: &dyn Language) -> Vec<TypedToken> {
         .iter()
         .enumerate()
         .filter_map(|(i, word)| {
-            let word_clean = word.trim_matches(|c: char| c.is_ascii_punctuation() && !"+-*/=".contains(c));
+            let word_clean =
+                word.trim_matches(|c: char| c.is_ascii_punctuation() && !"+-*/=".contains(c));
             if word_clean.is_empty() {
                 return None;
             }
@@ -64,7 +65,8 @@ pub fn tokenize_with_alternatives(
     let mut alternatives = Vec::new();
 
     for (i, word) in words.iter().enumerate() {
-        let word_clean = word.trim_matches(|c: char| c.is_ascii_punctuation() && !"+-*/=".contains(c));
+        let word_clean =
+            word.trim_matches(|c: char| c.is_ascii_punctuation() && !"+-*/=".contains(c));
         if word_clean.is_empty() {
             continue;
         }
@@ -112,7 +114,8 @@ pub fn tokenize_ontological(text: &str, language: &dyn Language) -> Vec<Token> {
         .iter()
         .enumerate()
         .filter_map(|(i, word)| {
-            let word_clean = word.trim_matches(|c: char| c.is_ascii_punctuation() && !"+-*/=".contains(c));
+            let word_clean =
+                word.trim_matches(|c: char| c.is_ascii_punctuation() && !"+-*/=".contains(c));
             if word_clean.is_empty() {
                 return None;
             }

--- a/crates/domains/src/cognitive/linguistics/lexicon/olia.rs
+++ b/crates/domains/src/cognitive/linguistics/lexicon/olia.rs
@@ -167,6 +167,5 @@ pub fn pos_to_olia_fragments(pos: PosTag) -> Vec<&'static str> {
         PosTag::Particle => vec!["Particle", "NegativeParticle", "InfinitiveParticle"],
         PosTag::Operator => vec!["Operator"],
         PosTag::Numeral => vec!["Numeral", "CardinalNumber", "OrdinalNumber"],
-        PosTag::Operator => vec!["Operator"],
     }
 }

--- a/crates/domains/src/cognitive/linguistics/lexicon/pos.rs
+++ b/crates/domains/src/cognitive/linguistics/lexicon/pos.rs
@@ -201,13 +201,6 @@ pub struct Numeral {
     pub text: String,
 }
 
-/// A mathematical operator: "+", "-", "*", "/", "=", "<", ">".
-/// OLiA: Operator.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Operator {
-    pub text: String,
-}
-
 /// A lexical entry — a word with its full part-of-speech structure.
 /// Each variant carries the rich type for that part of speech.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -226,7 +219,6 @@ pub enum LexicalEntry {
     Particle(Particle),
     Operator(Operator),
     Numeral(Numeral),
-    Operator(Operator),
 }
 
 impl LexicalEntry {
@@ -246,7 +238,6 @@ impl LexicalEntry {
             Self::Particle(p) => &p.text,
             Self::Operator(o) => &o.text,
             Self::Numeral(n) => &n.text,
-            Self::Operator(o) => &o.text,
         }
     }
 
@@ -316,7 +307,6 @@ impl LexicalEntry {
             Self::Particle(_) => PosTag::Particle,
             Self::Operator(_) => PosTag::Operator,
             Self::Numeral(_) => PosTag::Numeral,
-            Self::Operator(_) => PosTag::Operator,
         }
     }
 }


### PR DESCRIPTION
## Summary
The parallel Phase 3 operator PRs (#37 / #40 / #39) each added the `Operator` lexical entry. The merges left duplicate definitions behind, which break compilation of `pr4xis-domains`:

- duplicate `struct Operator` in `lexicon/pos.rs` (E0428 / E0119)
- duplicate `LexicalEntry::Operator(Operator)` enum variant + its `text()` / `pos_tag()` match arms (E0004 non-exhaustive cascade)
- duplicate `PosTag::Operator => vec["Operator"]` arm in `lexicon/olia.rs`

This removes the duplicates (deletions only — no behavior change). `cargo check --workspace` is green afterward.

This is the build fix the open upstream `master` PR needs, since the duplicates are currently on `master` (HEAD = PR #39).

## Test plan
- [x] `cargo check --workspace` compiles
- [x] `cargo test -p pr4xis-domains --lib lambek` — inline-LMF unit tests pass (LFS/WordNet integration tests remain env-gated)

https://claude.ai/code/session_01EMNkkfNvDiwS69XnhqdEpg

---
_Generated by [Claude Code](https://claude.ai/code/session_01EMNkkfNvDiwS69XnhqdEpg)_